### PR TITLE
Allow uninterned symbol for in-package

### DIFF
--- a/lisp/cont-comp.lisp
+++ b/lisp/cont-comp.lisp
@@ -35,7 +35,7 @@
 (xdefmacro eclipse:IN-PACKAGE (name)
   `(eval-when (:compile-toplevel :load-toplevel :execute)
      #+cmu (cl:in-package ,name)
-     (setq *package* (eclipse::pkg ,name))))
+     (setq *package* (eclipse::pkg ,(string name)))))
 
 
 (xdefmacro eclipse:SETF (&rest args &environment env)


### PR DESCRIPTION
Convert `name` parameter to string (as `defpackage` does it).
